### PR TITLE
Updates iotrace kernel module installation path to be not absolute

### DIFF
--- a/source/kernel/CMakeLists.txt
+++ b/source/kernel/CMakeLists.txt
@@ -56,7 +56,7 @@ if (DEFINED ENV{KERNEL_SRCS} OR
 
 	# Install kernel module and run depmod
 	install(FILES "${traceModulePath}"
-		DESTINATION "/lib/modules/${kernelName}/extra"
+		DESTINATION "lib/modules/${kernelName}/extra"
 		COMPONENT iotrace-install
 	)
 	install(CODE "execute_process(COMMAND depmod)"


### PR DESCRIPTION
Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>