### PR TITLE
Update setup_dependencies.sh to execute other_deps on Fedora

### DIFF
--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -132,6 +132,8 @@ case "${distro}" in
     info "Installing packages: ${packages}"
     dnf -y install ${packages}
     check_result $? "Cannot install required dependencies"
+
+    setup_other_deps
     ;;
 "UBUNTU18")
     info "Ubuntu 18 detected"


### PR DESCRIPTION
other_deps wasn't called on Fedora 30, so dependencies of submodules
weren't installed. The patch fixes the issue.

Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>