### PR TITLE
Iotrace now contains octf version when built from package_source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ package: all
 
 package_source: init
 	$(CMAKE) -P version.cmake
+	cd modules/open-cas-telemetry-framework && $(CMAKE) -P octf-version.cmake
 	make -C $(BUILD_DIR) package_source
 
 uninstall: init

--- a/package.cmake
+++ b/package.cmake
@@ -26,7 +26,7 @@ execute_process(
     && git ls-files --directory --ignored --others --exclude-standard | xargs -I{} printf {}\; \
     && git submodule foreach --recursive --quiet 'git ls-files --ignored --directory --others --exclude-standard \
     | grep -v tools/third_party | xargs -I{} printf \`pwd\`/{}\;'\
-    && git submodule foreach --recursive --quiet 'git ls-files --others --directory --exclude-standard \
+    && git submodule foreach --recursive --quiet 'git ls-files --others --directory --exclude-standard -x VERSION \
     | xargs -I{} printf \`pwd\`/{}\;'"
     OUTPUT_VARIABLE CPACK_SOURCE_IGNORE_FILES
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
Fixes #180

Signed-off-by: Mateusz Kozlowski <mateusz.kozlowski@intel.com>