### PR TITLE
Corrected module name in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sudo make install
 * Parse traces (note usage of path returned in --list-traces):
 
   ~~~{.sh}
-  iotrace --trace-parsing --io --path "kernel/2019-05-10_15:24:21" --format json
+  iotrace --trace-parser --io --path "kernel/2019-05-10_15:24:21" --format json
   ~~~
 
   Output:


### PR DESCRIPTION
Corrected module name in example. The module name to parse traces is called --trace-parser.

The example returned "Unknown command" when called with --trace-parsing.

Signed-off-by: GertPauwels <gert.pauwels@intel.com>